### PR TITLE
update amass Docker file for version 3.0+

### DIFF
--- a/docker/amass.yml
+++ b/docker/amass.yml
@@ -7,9 +7,6 @@ FROM ubuntu:16.04
 LABEL Name=amass_black Version=1.0.0
 
 COPY --from=build /go/bin/amass /bin/amass
-COPY --from=build /go/bin/amass.db /bin/amass.db
-COPY --from=build /go/bin/amass.netdomains /bin/amass.netdomains
-COPY --from=build /go/bin/amass.viz /bin/amass.viz
 
 RUN apt-get update
 RUN apt-get install -y software-properties-common


### PR DESCRIPTION
After version 3.0.0 all binaries were merged to one file:

https://github.com/OWASP/Amass/commit/cbc74ef1e207798dfecdd7a5fff073b1dbc9f8a8#diff-aedb9ef6a17a16fd320c5a93d5c7cc4f